### PR TITLE
Add shebang line to dkt2.py and make it executable

### DIFF
--- a/dkt2.py
+++ b/dkt2.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or


### PR DESCRIPTION
This makes it possible to run the program without explicitly specifying the
interpreter, and it also makes it clear that we're using python3.